### PR TITLE
get version

### DIFF
--- a/lib/Dist/Zilla/Plugin/ChangelogFromGit/Debian/Sequential.pm
+++ b/lib/Dist/Zilla/Plugin/ChangelogFromGit/Debian/Sequential.pm
@@ -44,7 +44,7 @@ sub render_changelog {
         $content = '';
     }
 
-    $prev_version = version->parse($prev_version);
+    $prev_version = version->parse(ref($prev_version) ? $prev_version->version : $prev_version);
 
     local $Text::Wrap::huge    = 'wrap';
     local $Text::Wrap::columns = $self->wrap_column();


### PR DESCRIPTION
```
$prev_version =  bless( {
                 'no_revision' => 1,
                 'epoch' => 0,
                 'version' => '0.015',
                 'revision' => 0,
                 'no_epoch' => 1
               }, 'Dpkg::Version' );
```
Got error "Invalid version format (non-numeric data) at /usr/share/perl5/Dist/Zilla/Plugin/ChangelogFromGit/Debian/Sequential.pm line 50."